### PR TITLE
bugfix (#42): 파일 선택 안하고 탐색기 종료했을 경우 빈 뱃지 생성되는 오류 수정

### DIFF
--- a/frontend/src/assets/modal.css
+++ b/frontend/src/assets/modal.css
@@ -230,13 +230,13 @@
 .form.form-file .file-badge {
   position: relative;
   display: inline-block;
-  max-width: 100px;
+  max-width: 250px;
   height: 30px;
   background-color: #ffc107;
   color: #fff;
   border-radius: 10px;
   padding: 0 10px;
-  margin-left: 6px;
+  margin-left: 10px;
 }
 
 .form.form-file .file-badge::after {
@@ -262,15 +262,28 @@
   white-space: nowrap;
 }
 
+.form__guide-msg {
+  display: block;
+  margin: 8px 0;
+  font-size: 14px;
+  margin: 15px 0;
+  color: #333;
+  padding-left: 10px;
+}
+
 .form__alert-msg {
+  display: none;
   margin: 8px 0;
   font-size: 14px;
   margin: 15px 0;
   color: #dc3545;
   padding-left: 10px;
-  visibility: hidden;
 }
 
 .empty-input + .form__alert-msg {
-  visibility: visible;
+  display: block;
+}
+
+.empty-input + .form__alert-msg + .form__guide-msg {
+  display: none;
 }

--- a/frontend/src/modal.html
+++ b/frontend/src/modal.html
@@ -131,6 +131,8 @@
           <input id="input-file" type="file" required>
         </div>
         <p class="form__alert-msg">여행사진을 첨부해주세요!</p>
+        <p class="form__guide-msg">이미지는 하나만 첨부해주세요.</p>
+
         <div class="options-wrap">
           <select name="" id="">
             <option value="" disabled selected>여행지</option>
@@ -213,10 +215,13 @@
       const inputs = document.querySelector('.modal-addpost .form  input[type="file"]');
       inputs.addEventListener('change', () => {
         const file = inputs.value.split('\\'); //경로
+        if (!file[0].length) return; //첨부된 사진이 없다면 뱃지 추가 로직 실행되지 않도록
+        $('.file-badge').length > 0 && $('.file-badge').remove(); // 사진 첨부되었는데 또 했을 경우 새로 추가한 사진만 남기기
 
         const fileBadge_element = '<span class="file-badge ellipse"><a href="#">' + file[file.length - 1] + '</a></span >';
         $('.js-form-file').append(fileBadge_element);
-        //백엔드에서 확인 가능    
+        $('.empty-input').removeClass('empty-input')
+        //formData에 저장된 이미지 경로는 백엔드에서만 확인 가능    
         const formData = new FormData();
         formData.set('file_', file);
       });


### PR DESCRIPTION
bugfix #42  
첨부 가능한 이미지 1개로 제한
이미지 선택 안하고 다른 영역 선택시 빈 뱃지 생성되는 버그 수정
